### PR TITLE
chore: add Vite preprocessorOptions

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,5 +12,13 @@ export default defineConfig(() => {
         "Cache-Control": "public, max-age=600",
       },
     },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          additionalData: (source, id) =>
+            id.endsWith('app.scss') ? source : '',
+        },
+      },
+    },
   }
 })


### PR DESCRIPTION
This Vite configuration works in `preview` and `dev` mode